### PR TITLE
Fixed deprecated $layout on controllers

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -23,9 +23,9 @@ class AppController extends BaseController
     public function beforeFilter(Event $event)
     {
         if ($this->authUser) {
-            $this->layout = 'Users.default';
+            $this->viewBuilder()->layout = 'Users.default';
         } else {
-            $this->layout = 'Users.login';
+            $this->viewBuilder()->layout = 'Users.login';
         }
 
         parent::beforeFilter($event);


### PR DESCRIPTION
`Deprecated (16384): Controller::$layout is deprecated. Use $this->viewBuilder()->layout() instead`
