### PR TITLE
Fixed typo in README.md, changed active to boolean (tinyint(1))

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ There are some configurations for email:
 - `Users.email.from` - Array to define the sender. Default `['admin@cakemanager.org' => 'Bob | CakeManager']`.
 - `Users.email.transport` - The transport to use. Default set to `default`.
 - `Users.email.afterRegister.subject` - The subject of the email sent when an user has been registered.
-- `Users.email.afterForget.subject` - The subject of the email sent when an user forgot his password.
+- `Users.email.afterForgot.subject` - The subject of the email sent when an user forgot his password.
 
 ### Users.defaultController
 The plugin has a default controller which contains all default user-related actions (login, logout, reset, forgot).

--- a/config/Migrations/20150615184659_initial.php
+++ b/config/Migrations/20150615184659_initial.php
@@ -56,9 +56,8 @@ class Initial extends AbstractMigration
                     'limit' => 11,
                     'null' => true,
                 ])
-                ->addColumn('active', 'integer', [
-                    'default' => 0,
-                    'limit' => 11,
+                ->addColumn('active', 'boolean', [
+                    'default' => false,
                     'null' => true,
                 ])
                 ->addColumn('request_key', 'string', [
@@ -90,9 +89,8 @@ class Initial extends AbstractMigration
             }
             if (!$table->hasColumn('active')) {
                 $table
-                    ->addColumn('active', 'integer', [
-                        'default' => 0,
-                        'limit' => 11,
+                    ->addColumn('active', 'boolean', [
+                        'default' => false,
                         'null' => true,
                     ])
                     ->save();

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -32,10 +32,10 @@ Configure::write('Users.fields', [
 if (Configure::read('Users.email') !== false) {
     Configure::write('Users.email.from', ['admin@cakemanager.org' => 'Bob | CakeManager']);
     Configure::write('Users.email.afterRegister', [
-        'subject' => __('Registration')
+        'subject' => __d('users', 'Registration')
     ]);
     Configure::write('Users.email.afterForgot', [
-        'subject' => __('Password request')
+        'subject' => __d('users', 'Password request')
     ]);
     Configure::write('Users.email.transport', 'default');
 }

--- a/src/Controller/Component/UserManagerComponent.php
+++ b/src/Controller/Component/UserManagerComponent.php
@@ -18,6 +18,7 @@ use Cake\Controller\Component;
 use Cake\Controller\ComponentRegistry;
 use Cake\Event\Event;
 
+
 /**
  * UserManager component
  */
@@ -103,13 +104,13 @@ class UserManagerComponent extends Component
                 $this->Controller->Auth->setUser($user);
                 return $this->Controller->redirect($this->Controller->Auth->redirectUrl());
             }
-            $this->Flash->error(__('Invalid username or password, try again'));
+            $this->Flash->error(__d('users', 'Invalid username or password, try again'));
         }
     }
 
     public function logout()
     {
-        $this->Controller->Flash->success(__('You are now logged out.'));
+        $this->Controller->Flash->success(__d('users', 'You are now logged out.'));
         return $this->Controller->redirect($this->Controller->Auth->logout());
     }
 
@@ -122,18 +123,18 @@ class UserManagerComponent extends Component
 
         // If the email and key doesn't match
         if (!$this->Controller->Users->validateRequestKey($email, $requestKey)) {
-            $this->Controller->Flash->error(__('Your account could not be activated.'));
+            $this->Controller->Flash->error(__d('users', 'Your account could not be activated.'));
             return $this->Controller->redirect('/login');
         }
 
         // If the user has been activated
         if ($this->Controller->Users->activate($email, $requestKey)) {
-            $this->Controller->Flash->success(__('Congratulations! Your account has been activated!'));
+            $this->Controller->Flash->success(__d('users', 'Congratulations! Your account has been activated!'));
             return $this->Controller->redirect('/login');
         }
 
         // If noting happened. Just for safety :)
-        $this->Controller->Flash->error(__('Your account could not be activated.'));
+        $this->Controller->Flash->error(__d('users', 'Your account could not be activated.'));
         return $this->Controller->redirect('/login');
     }
 
@@ -157,7 +158,7 @@ class UserManagerComponent extends Component
                 EventManager::instance()->dispatch($event);
             }
 
-            $this->Controller->Flash->success(__('Check your e-mail to change your password.'));
+            $this->Controller->Flash->success(__d('users', 'Check your e-mail to change your password.'));
             return $this->Controller->redirect($this->Controller->Auth->config('loginAction'));
         }
     }
@@ -166,13 +167,13 @@ class UserManagerComponent extends Component
     {
         // Redirect if user is already logged in
         if ($this->Controller->authUser) {
-            $this->Controller->Flash->error(__('Your account could not be activated.'));
+            $this->Controller->Flash->error(__d('users', 'Your account could not be activated.'));
             return $this->Controller->redirect($this->Controller->Auth->config('loginAction'));
         }
 
         // If the email and key doesn't match
         if (!$this->Controller->Users->validateRequestKey($email, $requestKey)) {
-            $this->Controller->Flash->error(__('Your account could not be activated.'));
+            $this->Controller->Flash->error(__d('users', 'Your account could not be activated.'));
             return $this->Controller->redirect($this->Controller->Auth->config('loginAction'));
         }
 
@@ -189,11 +190,11 @@ class UserManagerComponent extends Component
                 $user->set('request_key', null);
 
                 if ($this->Controller->Users->save($user)) {
-                    $this->Controller->Flash->success(__('Your password has been changed.'));
+                    $this->Controller->Flash->success(__d('users', 'Your password has been changed.'));
                     return $this->Controller->redirect($this->Controller->Auth->config('loginAction'));
                 }
             }
-            $this->Controller->Flash->error(__('Your account could not be activated.'));
+            $this->Controller->Flash->error(__d('users', 'Your account could not be activated.'));
         }
     }
 }

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -72,7 +72,7 @@ class UsersController extends AppController
             $this->Auth->setUser($this->Users->get($id));
             return $this->redirect($this->Auth->redirectUrl);
         }
-        $this->Flash->error(__('Invalid username or password, try again'));
+        $this->Flash->error(__d('users', 'Invalid username or password, try again'));
         return $this->redirect('/login');
     }
 

--- a/src/Event/UsersMailer.php
+++ b/src/Event/UsersMailer.php
@@ -44,17 +44,23 @@ class UsersMailer implements EventListenerInterface
     {
         if ($user->get('active') !== 1) {
             $email = new Email('default');
-
+            $activationUrl = [
+                'prefix' => false,
+                'plugin' => 'Users',
+                'controller' => 'Users',
+                'action' => 'activate',
+            ];
+            
+            if (Configure::check('Users.activationUrl')) {
+                $activationUrl = Configure::read('Users.activationUrl');
+            }
+            
+            $activationUrl[] = $user['email'];
+            $activationUrl[] = $user['request_key'];
+            
             $email->viewVars([
                 'user' => $user,
-                'activationUrl' => Router::fullBaseUrl() . Router::url([
-                        'prefix' => false,
-                        'plugin' => 'Users',
-                        'controller' => 'Users',
-                        'action' => 'activate',
-                        $user['email'],
-                        $user['request_key']
-                    ]),
+                'activationUrl' => Router::fullBaseUrl() . Router::url($activationUrl),
                 'baseUrl' => Router::fullBaseUrl(),
                 'loginUrl' => Router::fullBaseUrl() . '/login',
             ]);
@@ -72,17 +78,24 @@ class UsersMailer implements EventListenerInterface
     public function afterForgot($event, $user)
     {
         $email = new Email('default');
-
+        
+        $resetUrl = [
+            'prefix' => false,
+            'plugin' => 'Users',
+            'controller' => 'Users',
+            'action' => 'reset',
+        ];
+        
+        if (Configure::check('Users.resetUrl')) {
+            $resetUrl = Configure::read('Users.resetUrl');
+        }
+        
+        $resetUrl[] = $user['email'];
+        $resetUrl[] = $user['request_key'];
+        
         $email->viewVars([
             'user' => $user,
-            'resetUrl' => Router::fullBaseUrl() . Router::url([
-                    'prefix' => false,
-                    'plugin' => 'Users',
-                    'controller' => 'Users',
-                    'action' => 'reset',
-                    $user['email'],
-                    $user['request_key']
-                ]),
+            'resetUrl' => Router::fullBaseUrl() . Router::url($resetUrl),
             'baseUrl' => Router::fullBaseUrl(),
             'loginUrl' => Router::fullBaseUrl() . '/login',
         ]);

--- a/src/Locale/default.pot
+++ b/src/Locale/default.pot
@@ -1,0 +1,122 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2016-09-17 17:54+0000\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: Controller/UsersController.php:75
+#: Controller/Component/UserManagerComponent.php:107
+msgid "Invalid username or password, try again"
+msgstr ""
+
+#: Controller/Component/UserManagerComponent.php:113
+msgid "You are now logged out."
+msgstr ""
+
+#: Controller/Component/UserManagerComponent.php:126;137;170;176;197
+msgid "Your account could not be activated."
+msgstr ""
+
+#: Controller/Component/UserManagerComponent.php:132
+msgid "Congratulations! Your account has been activated!"
+msgstr ""
+
+#: Controller/Component/UserManagerComponent.php:161
+msgid "Check your e-mail to change your password."
+msgstr ""
+
+#: Controller/Component/UserManagerComponent.php:193
+msgid "Your password has been changed."
+msgstr ""
+
+#: Model/Table/UsersTable.php:147;158
+msgid "Passwords are not equal."
+msgstr ""
+
+#: Template/Email/html/after_forgot.ctp:2
+#: Template/Email/html/after_register.ctp:2
+#: Template/Email/text/after_forgot.ctp:1
+#: Template/Email/text/after_register.ctp:1
+msgid "Hello"
+msgstr ""
+
+#: Template/Email/html/after_forgot.ctp:6
+#: Template/Email/text/after_forgot.ctp:3
+msgid "You've got this e-mail because you lost your password at"
+msgstr ""
+
+#: Template/Email/html/after_forgot.ctp:7
+#: Template/Email/text/after_forgot.ctp:4
+msgid "Via the following url you will be able to set a new password:"
+msgstr ""
+
+#: Template/Email/html/after_forgot.ctp:11
+#: Template/Email/text/after_forgot.ctp:6
+msgid "After you've chosen your new password you are able to login at:"
+msgstr ""
+
+#: Template/Email/html/after_forgot.ctp:16
+msgid "If you didn't request a new password, you can ignore this e-mail."
+msgstr ""
+
+#: Template/Email/html/after_forgot.ctp:20
+#: Template/Email/html/after_register.ctp:15
+#: Template/Email/text/after_forgot.ctp:10
+#: Template/Email/text/after_register.ctp:8
+msgid "Greetz,"
+msgstr ""
+
+#: Template/Email/html/after_register.ctp:6
+#: Template/Email/text/after_register.ctp:3
+msgid "Welcome to"
+msgstr ""
+
+#: Template/Email/html/after_register.ctp:7
+#: Template/Email/text/after_register.ctp:4
+msgid "You need to activate your account first via this url:"
+msgstr ""
+
+#: Template/Email/html/after_register.ctp:7
+msgid "Activation"
+msgstr ""
+
+#: Template/Email/html/after_register.ctp:11
+#: Template/Email/text/after_register.ctp:6
+msgid "After activating you are able to login at:"
+msgstr ""
+
+#: Template/Email/text/after_forgot.ctp:8
+msgid "If you didn't requested a new password, you can ignore this e-mail."
+msgstr ""
+
+#: Template/Users/forgot.ctp:21
+msgid "Forgot password"
+msgstr ""
+
+#: Template/Users/forgot.ctp:24
+msgid "Request"
+msgstr ""
+
+#: Template/Users/forgot.ctp:26
+#: Template/Users/login.ctp:21;25
+msgid "Login"
+msgstr ""
+
+#: Template/Users/reset.ctp:5
+msgid "New Password"
+msgstr ""
+
+#: Template/Users/reset.ctp:9
+msgid "Save"
+msgstr ""
+

--- a/src/Locale/hu/users.po
+++ b/src/Locale/hu/users.po
@@ -1,0 +1,125 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2016-09-17 17:54+0000\n"
+"PO-Revision-Date: 2016-09-17 19:56+0100\n"
+"Last-Translator: Márton Miklós <martonmiklosqdev@gmail.com>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.5.4\n"
+"Language: Hungarian\n"
+
+#: Controller/UsersController.php:75
+#: Controller/Component/UserManagerComponent.php:107
+msgid "Invalid username or password, try again"
+msgstr "Érvénytelen felhasználónév/jelszó"
+
+#: Controller/Component/UserManagerComponent.php:113
+msgid "You are now logged out."
+msgstr "Sikeres kijelentkezés"
+
+#: Controller/Component/UserManagerComponent.php:126;137;170;176;197
+msgid "Your account could not be activated."
+msgstr "A felhasználói fiókod aktiválása sikertelen"
+
+#: Controller/Component/UserManagerComponent.php:132
+msgid "Congratulations! Your account has been activated!"
+msgstr "A felhasználói fiókod sikeresen aktiválva"
+
+#: Controller/Component/UserManagerComponent.php:161
+msgid "Check your e-mail to change your password."
+msgstr "A jelszó visszaállító e-mailt sikeresen elküldtük az e-mail címedre."
+
+#: Controller/Component/UserManagerComponent.php:193
+msgid "Your password has been changed."
+msgstr "A jelszavad sikeresen megváltoztatva"
+
+#: Model/Table/UsersTable.php:147;158
+msgid "Passwords are not equal."
+msgstr "A megadott jelszavak nem egyeznek meg"
+
+#: Template/Email/html/after_forgot.ctp:2
+#: Template/Email/html/after_register.ctp:2
+#: Template/Email/text/after_forgot.ctp:1
+#: Template/Email/text/after_register.ctp:1
+msgid "Hello"
+msgstr "Szia"
+
+#: Template/Email/html/after_forgot.ctp:6
+#: Template/Email/text/after_forgot.ctp:3
+msgid "You've got this e-mail because you lost your password at"
+msgstr ""
+"Azért kaptad ezt az e-mailt mert valaki jelszóvisszaállítást kért itt: "
+
+#: Template/Email/html/after_forgot.ctp:7
+#: Template/Email/text/after_forgot.ctp:4
+msgid "Via the following url you will be able to set a new password:"
+msgstr "A következő linken adhatod meg az új jelszavadat: "
+
+#: Template/Email/html/after_forgot.ctp:11
+#: Template/Email/text/after_forgot.ctp:6
+msgid "After you've chosen your new password you are able to login at:"
+msgstr "Az új jelszó megadása után itt tudsz majd bejelentkezni:"
+
+#: Template/Email/html/after_forgot.ctp:16
+msgid "If you didn't request a new password, you can ignore this e-mail."
+msgstr ""
+"Ha nem te igényeltél jelszóvisszaállítást, nyugodtan hagyd figyelmen kívül "
+"ezt az e-mailt."
+
+#: Template/Email/html/after_forgot.ctp:20
+#: Template/Email/html/after_register.ctp:15
+#: Template/Email/text/after_forgot.ctp:10
+#: Template/Email/text/after_register.ctp:8
+msgid "Greetz,"
+msgstr "Üdvözlettel,"
+
+#: Template/Email/html/after_register.ctp:6
+#: Template/Email/text/after_register.ctp:3
+msgid "Welcome to"
+msgstr "Üdvözöllek itt"
+
+#: Template/Email/html/after_register.ctp:7
+#: Template/Email/text/after_register.ctp:4
+msgid "You need to activate your account first via this url:"
+msgstr "A felhasználói fiókodat először aktiválnod kell itt:"
+
+#: Template/Email/html/after_register.ctp:7
+msgid "Activation"
+msgstr "Aktiválás"
+
+#: Template/Email/html/after_register.ctp:11
+#: Template/Email/text/after_register.ctp:6
+msgid "After activating you are able to login at:"
+msgstr "Az új jelszó megadása után itt tudsz majd bejelentkezni:"
+
+#: Template/Email/text/after_forgot.ctp:8
+msgid "If you didn't requested a new password, you can ignore this e-mail."
+msgstr ""
+"Ha nem te igényeltél jelszóvisszaállítást, nyugodtan hagyd figyelmen kívül "
+"ezt az e-mailt."
+
+#: Template/Users/forgot.ctp:21
+msgid "Forgot password"
+msgstr "Elfelejtett jelszó"
+
+#: Template/Users/forgot.ctp:24
+msgid "Request"
+msgstr "Igénylés"
+
+#: Template/Users/forgot.ctp:26 Template/Users/login.ctp:21;25
+msgid "Login"
+msgstr "Bejelentkezés"
+
+#: Template/Users/reset.ctp:5
+msgid "New Password"
+msgstr "Új jelszó"
+
+#: Template/Users/reset.ctp:9
+msgid "Save"
+msgstr "Mentés"

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -144,7 +144,7 @@ class UsersTable extends Table
                     }
                     return true;
                 },
-                'message' => __('Passwords are not equal.'),
+                'message' => __d('users', 'Passwords are not equal.'),
             ]);
 
         $validator
@@ -155,7 +155,7 @@ class UsersTable extends Table
                     }
                     return true;
                 },
-                'message' => __('Passwords are not equal.'),
+                'message' => __d('users', 'Passwords are not equal.'),
             ]);
 
         return $validator;

--- a/src/Template/Email/html/after_forgot.ctp
+++ b/src/Template/Email/html/after_forgot.ctp
@@ -1,23 +1,23 @@
 <p style="font-family: Calibri, Arial">
-    Hello <?= $user->email ?>,
+    <?= __d('users', 'Hello') ?> <?= $user->email ?>,
 </p>
 
 <p style="font-family: Calibri, Arial">
-    You've got this e-mail because you lost your password at <a href="<?= $baseUrl ?>"><?= $baseUrl ?></a>.<br>
-    Via the following url you will be able to set a new password: <a href="<?= $resetUrl ?>">Reset new Password</a>.
+    <?= __d('users', "You've got this e-mail because you lost your password at") ?> <a href="<?= $baseUrl ?>"><?= $baseUrl ?></a>.<br>
+    <?= __d('users', "Via the following url you will be able to set a new password:") ?> <a href="<?= $resetUrl ?>">Reset new Password</a>.
 </p>
 
 <p style="font-family: Calibri, Arial">
-    After you've chosen your new password you are able to login at: <a href="<?= $loginUrl ?>"><?= $loginUrl ?></a>.
+    <?= __d('users', "After you've chosen your new password you are able to login at:") ?> <a href="<?= $loginUrl ?>"><?= $loginUrl ?></a>.
 </p>
 
 
 <p style="font-family: Calibri, Arial">
-    If you didn't request a new password, you can ignore this e-mail and continue your account at <?= $baseUrl ?>.
+    <?= __d('users', "If you didn't request a new password, you can ignore this e-mail.") ?>
 </p>
 
 <p style="font-family: Calibri, Arial">
-    Greetz,
+    <?= __d('users', 'Greetz,') ?>
 </p>
 
 <p style="font-family: Calibri, Arial">

--- a/src/Template/Email/html/after_register.ctp
+++ b/src/Template/Email/html/after_register.ctp
@@ -1,18 +1,18 @@
 <p style="font-family: Calibri, Arial">
-    Hello <?= $user->email ?>,
+    <?= __d('users', 'Hello') ?> <?= $user->email ?>,
 </p>
 
 <p style="font-family: Calibri, Arial">
-    Welcome to <a href="<?= $baseUrl ?>"><?= $baseUrl ?></a>!<br>
-    You need to activate your account first via this url: <a href="<?= $activationUrl ?>">Activation</a>.
+    <?= __d('users', 'Welcome to')?> <a href="<?= $baseUrl ?>"><?= $baseUrl ?></a>!<br>
+    <?= __d('users', 'You need to activate your account first via this url:') ?> <a href="<?= $activationUrl ?>"><?= __d('users', 'Activation') ?></a>.
 </p>
 
 <p style="font-family: Calibri, Arial">
-    After activating you are able to login at: <a href="<?= $loginUrl ?>"><?= $loginUrl ?></a>.
+    <?= __d('users', 'After activating you are able to login at:') ?> <a href="<?= $loginUrl ?>"><?= $loginUrl ?></a>.
 </p>
 
 <p style="font-family: Calibri, Arial">
-    Greetz,
+    <?= __d('users', 'Greetz,') ?>
 </p>
 
 <p style="font-family: Calibri, Arial">

--- a/src/Template/Email/text/after_forgot.ctp
+++ b/src/Template/Email/text/after_forgot.ctp
@@ -1,12 +1,12 @@
-Hello <?= $user->email ?>,
+<?= __d('users', "Hello")?> <?= $user->email ?>,
 
-You've got this e-mail because you lost your password at <?= $baseUrl ?>.
-Via the following url you will be able to set a new password: <?= $resetUrl ?>.
+<?= __d('users', "You've got this e-mail because you lost your password at") ?> <?= $baseUrl ?>.
+<?= __d('users', "Via the following url you will be able to set a new password:") ?> <?= $resetUrl ?>.
 
-After you've chosen your new password you are able to login at: <?= $loginUrl ?>.
+<?= __d('users', "After you've chosen your new password you are able to login at:") ?> <?= $loginUrl ?>.
 
-If you didn't request a new password, you can ignore this e-mail and continue your account at <?= $baseUrl ?>.
+<?= __d('users', "If you didn't requested a new password, you can ignore this e-mail.") ?>
 
-Greetz,
+<?= __d('users', "Greetz,") ?>
 
 <?= $baseUrl ?>

--- a/src/Template/Email/text/after_register.ctp
+++ b/src/Template/Email/text/after_register.ctp
@@ -1,10 +1,10 @@
-Hello <?= $user->email ?>,
+<?= __d('users', 'Hello')?> <?= $user->email ?>,
 
-Welcome to <?= $baseUrl ?>!
-You need to activate your account first via this url: <?= $activationUrl ?>.
+<?= __d('users', 'Welcome to') ?> <?= $baseUrl ?>!
+<?= __d('users', 'You need to activate your account first via this url:') ?> <?= $activationUrl ?>.
 
-After activating you are able to login at: <?= $loginUrl ?>.
+<?= __d('users', 'After activating you are able to login at:') ?> <?= $loginUrl ?>.
 
-Greetz,
+<?= __d('users', 'Greetz,') ?>
 
 <?= $baseUrl ?>

--- a/src/Template/Users/forgot.ctp
+++ b/src/Template/Users/forgot.ctp
@@ -18,10 +18,10 @@ use Cake\Core\Configure;
     <?= $this->Flash->render('auth') ?>
     <?= $this->Form->create() ?>
     <fieldset>
-        <legend><?= __('Forgot password') ?></legend>
+        <legend><?= __d('users', 'Forgot password') ?></legend>
         <?= $this->Form->input(Configure::read('Users.fields.username')) ?>
     </fieldset>
-    <?= $this->Form->button(__('Request')); ?>
+    <?= $this->Form->button(__d('users', 'Request')); ?>
     <?= $this->Form->end() ?>
-    <?= $this->Html->link('Login', ['action' => 'login']); ?>
+    <?= $this->Html->link(__d('users', 'Login'), ['action' => 'login']); ?>
 </div>

--- a/src/Template/Users/login.ctp
+++ b/src/Template/Users/login.ctp
@@ -18,11 +18,11 @@ use Cake\Core\Configure;
     <?= $this->Flash->render('auth') ?>
     <?= $this->Form->create() ?>
     <fieldset>
-        <legend><?= __('Login') ?></legend>
+        <legend><?= __d('users', 'Login') ?></legend>
         <?= $this->Form->input(Configure::read('Users.fields.username')) ?>
         <?= $this->Form->input(Configure::read('Users.fields.password'), ['value' => '']) ?>
     </fieldset>
-    <?= $this->Form->button(__('Login')); ?>
+    <?= $this->Form->button(__d('users', 'Login')); ?>
     <?= $this->Form->end() ?>
     <?= $this->Html->link('Forgot password', ['action' => 'forgot']); ?>
 </div>

--- a/src/Template/Users/reset.ctp
+++ b/src/Template/Users/reset.ctp
@@ -2,10 +2,10 @@
     <?= $this->Flash->render('auth') ?>
     <?= $this->Form->create() ?>
     <fieldset>
-        <legend><?= __('New Password') ?></legend>
+        <legend><?= __d('users', 'New Password') ?></legend>
         <?= $this->Form->input('new_password', ['type' => 'password', 'value' => '']) ?>
         <?= $this->Form->input('confirm_password', ['type' => 'password', 'value' => '']) ?>
     </fieldset>
-    <?= $this->Form->button(__('Save')); ?>
+    <?= $this->Form->button(__d('users', 'Save')); ?>
     <?= $this->Form->end() ?>
 </div>


### PR DESCRIPTION
Fixed typo in README.md -> the Users.email.afterForget.subject is Users.email.afterForgot.subject
Changed active field's type in the migration script to boolean (tinyint(1))
Refactored i18n macros from __(...) to __d('users', ...)
Added Hungarian localization
Added resetUrl and activationUrl to the Config to be able to use the plugin controllerless without route manipulation
